### PR TITLE
twist_controller and the related scripts were updated

### DIFF
--- a/ros/src/styx/bridge.py
+++ b/ros/src/styx/bridge.py
@@ -93,6 +93,7 @@ class Bridge(object):
         tw = TwistStamped()
         tw.twist.linear.x = velocity
         tw.twist.angular.z = angular
+        tw.header.stamp = rospy.Time.now()
         return tw
 
     def create_steer(self, val):

--- a/ros/src/twist_controller/lowpass.py
+++ b/ros/src/twist_controller/lowpass.py
@@ -1,8 +1,13 @@
 
+"""
+First order Low-pass filter:
+https://en.wikipedia.org/wiki/Low-pass_filter
+"""
+
+
 class LowPassFilter(object):
-    def __init__(self, tau, ts):
-        self.a = 1. / (tau / ts + 1.)
-        self.b = tau / ts / (tau / ts + 1.);
+    def __init__(self, time_interval, time_constant):
+        self.alpha = time_interval / (time_interval + time_constant)
 
         self.last_val = 0.
         self.ready = False
@@ -10,9 +15,13 @@ class LowPassFilter(object):
     def get(self):
         return self.last_val
 
+    def reset(self):
+        self.last_val = 0.
+        self.ready = False
+
     def filt(self, val):
         if self.ready:
-            val = self.a * val + self.b * self.last_val
+            val = self.alpha * val + (1. - self.alpha) * self.last_val
         else:
             self.ready = True
 

--- a/ros/src/twist_controller/pid.py
+++ b/ros/src/twist_controller/pid.py
@@ -20,10 +20,10 @@ class PID(object):
     def step(self, error, sample_time):
         self.last_int_val = self.int_val
 
-        integral = self.int_val + error * sample_time;
-        derivative = (error - self.last_error) / sample_time;
+        integral = self.int_val + error * sample_time
+        derivative = (error - self.last_error) / sample_time
 
-        y = self.kp * error + self.ki * self.int_val + self.kd * derivative;
+        y = self.kp * error + self.ki * self.int_val + self.kd * derivative
         val = max(self.min, min(y, self.max))
 
         if val > self.max:

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -43,14 +43,14 @@ class Controller(object):
         self.throttle_pid = PID(
             10.,
             .0,
-            10.,
+            5.,
             0,
             1
         )
         self.steer_pid = PID(
             1.0,
             .0,
-            10.0,
+            5.0,
             -params['max_steer_angle'],
             params['max_steer_angle']
         )

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -8,6 +8,7 @@ from yaw_controller import YawController
 from lowpass import LowPassFilter
 from pid import PID
 import math
+import rospy
 
 
 class Controller(object):
@@ -20,8 +21,19 @@ class Controller(object):
             max_lat_accel = params['max_lat_accel'],
             max_steer_angle = params['max_steer_angle'])
 
-        self.yaw_filter = LowPassFilter(0.5, 0.1)   
-        self.filter_yaw = False
+        self.prev_linear_velocity = 0.0
+
+        self.filter_steer = True
+        if self.filter_steer:
+            self.steer_filter = LowPassFilter(time_interval=0.1,
+                                              time_constant=1.0)
+
+        self.filter_throttle = True
+        if self.filter_throttle:
+            self.throttle_filter = LowPassFilter(time_interval=0.1,
+                                                 time_constant=0.1)
+
+        self.break_constant = 0.1
 
         self.vehicle_mass = params['vehicle_mass']
         self.fuel_capacity = params['fuel_capacity']
@@ -29,16 +41,16 @@ class Controller(object):
         self.wheel_radius = params['wheel_radius']
         self.sample_rate = params['sample_rate']
         self.throttle_pid = PID(
-            1.0,
-            .02,
-            .2,
+            10.,
+            .0,
+            10.,
             0,
             1
         )
         self.steer_pid = PID(
-            1.,
+            1.0,
             .0,
-            .6,
+            10.0,
             -params['max_steer_angle'],
             params['max_steer_angle']
         )
@@ -46,25 +58,30 @@ class Controller(object):
         # assume tank is full when computing total mass of car
         self.total_mass = self.vehicle_mass + self.fuel_capacity * GAS_DENSITY
 
-
     def control(self, linear_velocity, angular_velocity, current_velocity,
                 enabled = True):
 
-        if self.filter_yaw:
-            angular_velocity = self.yaw_filter.filt(angular_velocity)
-
         velocity_diff = linear_velocity - current_velocity
+
+        target_velocity_diff = linear_velocity - self.prev_linear_velocity
+
+        time_interval = 1.0 / self.sample_rate
 
         throttle = 0.0
         brake = 0.0
         steer = 0.0
         if enabled:
-            if velocity_diff > 0:
-                throttle = self.throttle_pid.step(velocity_diff, 1.0 / self.sample_rate)
-            else:
-                brake = -velocity_diff * self.total_mass * self.wheel_radius
+            if target_velocity_diff < 0.0 or linear_velocity < 1.0:
+                # Brake in torque [N*m]
+                acc = velocity_diff/time_interval # Required acceleration
+                brake = max(self.break_constant*math.fabs(acc), 0.19) * self.total_mass * self.wheel_radius
                 self.throttle_pid.reset()
+            else:
+                throttle = self.throttle_pid.step(velocity_diff, time_interval)
 
+                # Pass the low-pass filter
+                if self.filter_throttle:
+                    throttle = self.throttle_filter.filt(throttle)
 
             steer = self.yaw_controller.get_steering(
                 linear_velocity,
@@ -72,10 +89,31 @@ class Controller(object):
                 current_velocity
             )
             if USE_STEER_PID:
-                steer = self.steer_pid.step(steer, 1.0 / self.sample_rate)
+                steer = self.steer_pid.step(angular_velocity, time_interval)
+            else:
+                steer = self.yaw_controller.get_steering(
+                    linear_velocity,
+                    angular_velocity,
+                    current_velocity
+                )
+            # Pass the low-pass filter
+            if self.filter_steer:
+                steer = self.steer_filter.filt(steer)
+
+            # Update the previous target
+            self.prev_linear_velocity = linear_velocity
 
         else:
             self.throttle_pid.reset()
             self.steer_pid.reset()
+            self.throttle_filter.reset()
+            self.steer_filter.reset()
+
+        # Logwarn for Debugging PID
+        # run ```rosrun rqt_pt rqt_plot``` and set topics for plotting the actual velocity
+        # rospy.logwarn("Throttle : {}".format(throttle))
+        # rospy.logwarn("   Brake : {}".format(brake))
+        # rospy.logwarn("   Steer : {}".format(steer))
+        # rospy.logwarn("--- ")
 
         return throttle, brake, steer

--- a/ros/src/twist_controller/yaw_controller.py
+++ b/ros/src/twist_controller/yaw_controller.py
@@ -1,5 +1,6 @@
 from math import atan
 
+
 class YawController(object):
     def __init__(self, wheel_base, steer_ratio, min_speed, max_lat_accel, max_steer_angle):
         self.wheel_base = wheel_base
@@ -10,7 +11,6 @@ class YawController(object):
         self.min_angle = -max_steer_angle
         self.max_angle = max_steer_angle
 
-
     def get_angle(self, radius):
         angle = atan(self.wheel_base / radius) * self.steer_ratio
         return max(self.min_angle, min(self.max_angle, angle))
@@ -19,7 +19,7 @@ class YawController(object):
         angular_velocity = current_velocity * angular_velocity / linear_velocity if abs(linear_velocity) > 0. else 0.
 
         if abs(current_velocity) > 0.1:
-            max_yaw_rate = abs(self.max_lat_accel / current_velocity);
+            max_yaw_rate = abs(self.max_lat_accel / current_velocity)
             angular_velocity = max(-max_yaw_rate, min(max_yaw_rate, angular_velocity))
 
-        return self.get_angle(max(current_velocity, self.min_speed) / angular_velocity) if abs(angular_velocity) > 0. else 0.0;
+        return self.get_angle(max(current_velocity, self.min_speed) / angular_velocity) if abs(angular_velocity) > 0. else 0.0


### PR DESCRIPTION
NOTE : 

I think this is a bug in the original Udacity's branch, the timestamps are missed at the target twist creation. So I add the timestamp at "ros/src/styx/bridge.py". This update enables us to plot the twist status in rqt_plot.