### PR TITLE
Update PID constants and the brake logic

### DIFF
--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -43,7 +43,7 @@ class DBWNode(object):
 
         self.params['vehicle_mass'] = rospy.get_param('~vehicle_mass', 1736.35)
         self.params['fuel_capacity'] = rospy.get_param('~fuel_capacity', 13.5)
-        self.params['brake_deadband'] = rospy.get_param('~brake_deadband', .1)
+        self.params['brake_deadband'] = rospy.get_param('~brake_deadband', 3.0)
         self.params['decel_limit'] = rospy.get_param('~decel_limit', -5)
         self.params['accel_limit'] = rospy.get_param('~accel_limit', 1.)
         self.params['wheel_radius'] = rospy.get_param('~wheel_radius', 0.2413)

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -33,7 +33,7 @@ class Controller(object):
             self.throttle_filter = LowPassFilter(time_interval=0.1,
                                                  time_constant=0.1)
 
-        self.break_constant = 0.3
+        self.break_constant = 0.33
 
         self.vehicle_mass = params['vehicle_mass']
         self.fuel_capacity = params['fuel_capacity']
@@ -71,11 +71,17 @@ class Controller(object):
         brake = 0.0
         steer = 0.0
         if enabled:
-            if velocity_diff < 1.0 and (target_velocity_diff < 0.0 or linear_velocity < self.brake_deadband):
+            if (velocity_diff < 1.0 and target_velocity_diff < 0.0) or linear_velocity < self.brake_deadband:
                 # Brake in torque [N*m]
                 acc = velocity_diff/time_interval # Required acceleration
-                brake = max(self.break_constant*math.fabs(acc), 0.19) * self.total_mass * self.wheel_radius
+                brake = self.break_constant*max(math.fabs(acc), 0.19) * self.total_mass * self.wheel_radius
+
+                # Reset controllers
+                self.throttle_filter.reset()
                 self.throttle_pid.reset()
+                self.steer_filter.reset()
+                if USE_STEER_PID:
+                    self.steer_pid.reset()
             else:
                 throttle = self.throttle_pid.step(velocity_diff, time_interval)
 

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -26,7 +26,7 @@ class Controller(object):
         self.filter_steer = True
         if self.filter_steer:
             self.steer_filter = LowPassFilter(time_interval=0.1,
-                                              time_constant=1.0)
+                                              time_constant=0.66)
 
         self.filter_throttle = True
         if self.filter_throttle:
@@ -48,9 +48,9 @@ class Controller(object):
             1
         )
         self.steer_pid = PID(
-            1.0,
+            3.0,
             .0,
-            5.0,
+            10.0,
             -params['max_steer_angle'],
             params['max_steer_angle']
         )
@@ -71,7 +71,7 @@ class Controller(object):
         brake = 0.0
         steer = 0.0
         if enabled:
-            if target_velocity_diff < 0.0 or linear_velocity < 1.0:
+            if velocity_diff < 1.0 and (target_velocity_diff < 0.0 or linear_velocity < 1.0):
                 # Brake in torque [N*m]
                 acc = velocity_diff/time_interval # Required acceleration
                 brake = max(self.break_constant*math.fabs(acc), 0.19) * self.total_mass * self.wheel_radius

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -33,7 +33,7 @@ class Controller(object):
             self.throttle_filter = LowPassFilter(time_interval=0.1,
                                                  time_constant=0.1)
 
-        self.break_constant = 0.1
+        self.break_constant = 0.3
 
         self.vehicle_mass = params['vehicle_mass']
         self.fuel_capacity = params['fuel_capacity']
@@ -71,7 +71,7 @@ class Controller(object):
         brake = 0.0
         steer = 0.0
         if enabled:
-            if velocity_diff < 1.0 and (target_velocity_diff < 0.0 or linear_velocity < 1.0):
+            if velocity_diff < 1.0 and (target_velocity_diff < 0.0 or linear_velocity < self.brake_deadband):
                 # Brake in torque [N*m]
                 acc = velocity_diff/time_interval # Required acceleration
                 brake = max(self.break_constant*math.fabs(acc), 0.19) * self.total_mass * self.wheel_radius


### PR DESCRIPTION
The main update is the 74-th line. This update make the braking smoother than before.

The brake is enabled only when 
1. the target velocity is decreasing AND the difference of velocities (the target velocity - the actual velocity) is less than 1.0 m/s
2. or the target velocity is sufficiently small
